### PR TITLE
fix: BTC and LTC channel opening

### DIFF
--- a/scripts/xud-simnet-channels
+++ b/scripts/xud-simnet-channels
@@ -36,7 +36,7 @@ if [ "$needBTC" = 1 ]; then
 	echo "Opening BTC channel"
 	let server="$RANDOM % 3 +1"
 	let head="$server*2"
-	connectstr=`xucli listpeers|egrep -A1 '"BTC"|address'|sed -n '1p;7p;13p;5p;11p;17p'|head -n $head|tail -n 2|sed 's/\"//g'|sed 's/\,//'|sed 's/ //g'|tac|paste -d "@"  - -|sed 's/address://'|cut -d ":" -f1`
+	connectstr=`xucli -j listpeers|egrep -A1 '"BTC"|address'|sed -n '1p;7p;13p;5p;11p;17p'|head -n $head|tail -n 2|sed 's/\"//g'|sed 's/\,//'|sed 's/ //g'|tac|paste -d "@"  - -|sed 's/address://'|cut -d ":" -f1`
 	echo "open channel with $connectstr"
 	lndbtc-lncli connect $connectstr:10012
 fi
@@ -45,7 +45,7 @@ if [ "$needLTC" = 1 ]; then
 	echo "Opening LTC channel"
 	let server="$RANDOM % 3 +1"
 	let head="$server*2"
-	connectstr=`xucli listpeers|egrep -A1 '"LTC"|address'|sed -n '1p;7p;13p;5p;11p;17p'|head -n $head|tail -n 2|sed 's/\"//g'|sed 's/\,//'|sed 's/ //g'|tac|paste -d "@"  - -|sed 's/address://'|cut -d ":" -f1`
+	connectstr=`xucli -j listpeers|egrep -A1 '"LTC"|address'|sed -n '1p;7p;13p;5p;11p;17p'|head -n $head|tail -n 2|sed 's/\"//g'|sed 's/\,//'|sed 's/ //g'|tac|paste -d "@"  - -|sed 's/address://'|cut -d ":" -f1`
 	echo "open channel with $connectstr"
 	lndltc-lncli connect $connectstr:10011
 fi


### PR DESCRIPTION
Because of the changes in https://github.com/ExchangeUnion/xud/pull/926 the channel opening of BTC and LTC broke as the LNDs couldn't connect to the simnet nodes.

This PR fixes that issue by calling `xucli listpeers ` with `-j`